### PR TITLE
✨ Ajout des boutons autour du champ de saisie des messages

### DIFF
--- a/frontend/src/components/ChatBox.vue
+++ b/frontend/src/components/ChatBox.vue
@@ -1,14 +1,27 @@
 <template>
   <v-flex @submit.prevent="sendMessage(message)">
-    <v-form style="width:100%">
-    <v-text-field
-      label="Solo"
-      placeholder="Saisir un message..."
-      v-model="message"
-      solo
-      ref="message"
+    <v-form style="width:90%" class="ma-auto pt-3">
+      <v-text-field
+        ref="message"
+        v-model="message"
+        label="Solo"
+        placeholder="Saisir un message..."
+        solo
+        append-icon="mdi-send"
+        @click:append="sendMessage(message)"
       >
-    </v-text-field>
+        <template v-slot:prepend>
+          <v-btn icon>
+            <v-icon>mdi-vector-polygon</v-icon>
+          </v-btn>
+          <v-btn icon>
+            <v-icon>mdi-file-plus</v-icon>
+          </v-btn>
+          <v-btn icon>
+            <v-icon>mdi-clipboard-list-outline</v-icon>
+          </v-btn>
+        </template>
+      </v-text-field>
     </v-form>
   </v-flex>
 </template>


### PR DESCRIPTION
Ajout des boutons pour le drawpad, l'envoi de fichiers, les sondages et l'envoi du message.

![image](https://user-images.githubusercontent.com/33122214/72438947-3fa38000-37a6-11ea-9c76-010349308dcc.png)
